### PR TITLE
Bogdan test branch

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,5 +6,6 @@ fb_pages = [
     'https://www.facebook.com/pg/UniversitateaRomanoAmericana',
     'https://www.facebook.com/pg/muzeul.literaturii.romane',
     'https://www.facebook.com/pg/CentruldeTeatruEducational',
-    'https://www.facebook.com/TNB.Ro'
+    'https://www.facebook.com/TNB.Ro',
+    'https://www.facebook.com/InterContinentalBucharestHotel'
 ]

--- a/manifest_cultural/models.py
+++ b/manifest_cultural/models.py
@@ -9,8 +9,8 @@ class Event(db.Model):
     venue = db.Column(db.String)
     start_date = db.Column(db.DateTime)
     end_date = db.Column(db.DateTime)
-    first_date = db.Column(db.String)
-    second_date = db.Column(db.String)
+    first_date = db.Column(db.DateTime)
+    second_date = db.Column(db.DateTime)
 
     def __repr__(self):
         return "<Event(name='%s', venue='%s', start_date='%s', end_date='%s', first_date='%s', second_date='%s')>" % (

--- a/manifest_cultural/models.py
+++ b/manifest_cultural/models.py
@@ -9,8 +9,10 @@ class Event(db.Model):
     venue = db.Column(db.String)
     start_date = db.Column(db.DateTime)
     end_date = db.Column(db.DateTime)
+    first_date = db.Column(db.String)
+    second_date = db.Column(db.String)
 
     def __repr__(self):
-        return "<Event(name='%s', venue='%s', start_date='%s', end_date='%s')>" % (
-            self.name, self.venue, self.start_date, self.end_date
+        return "<Event(name='%s', venue='%s', start_date='%s', end_date='%s', first_date='%s', second_date='%s')>" % (
+            self.name, self.venue, self.start_date, self.end_date, self.first_date, self.second_date
         )

--- a/manifest_cultural/templates/index.html
+++ b/manifest_cultural/templates/index.html
@@ -86,7 +86,11 @@
              autosize(document.getElementById('edit-area'));" method="post">
 
         {% for event in events: %}
-          <input type="checkbox" name="new_events" value="{{ event.name }} @ {{ event.venue }} at {{ event.start_date }}">  {{ event.name }} @ {{ event.venue }} at {{ event.start_date }}<br>
+          {% if event.start_date: %}
+            <input type="checkbox" name="new_events" value="{{ event.name }} @ {{ event.venue }} at {{ event.start_date }}">  {{ event.name }} @ {{ event.venue }} at {{ event.start_date }}<br>
+          {% else: %}
+            <input type="checkbox" name="new_events" value="{{ event.name }} @ {{ event.venue }} on {{ event.first_date }} and {{ event.second_date }}">  {{ event.name }} @ {{ event.venue }} on {{ event.first_date }} and {{ event.second_date }}<br>
+          {% endif %}
         {% endfor %}
 
           <br>

--- a/scrape_events.py
+++ b/scrape_events.py
@@ -28,8 +28,8 @@ class Event(Base):
     venue = Column(String)
     start_date = Column(DateTime)
     end_date = Column(DateTime)
-    first_date = Column(String)
-    second_date = Column(String)
+    first_date = Column(DateTime)
+    second_date = Column(DateTime)
 
     def __repr__(self):
         return "<Event(name='%s', venue='%s', start_date='%s', end_date='%s', first_date='%s'), second_date='%s'>" % (
@@ -126,17 +126,36 @@ def process_event(element_container):
 
 def process_recurring_event(recurring_element_container):
 
+#list with the next 2 dates for recurring events
     next_dates = recurring_element_container.find_elements_by_css_selector('._2l43.clearfix._ikh')
+
+#extract First Date from recurring list
+    month_first = next_dates[0].find_element_by_class_name('_5a4-').text
+    day_first = next_dates[0].find_element_by_class_name('_5a4z').text
+    raw_time_str_first = next_dates[0].find_element_by_css_selector('._2l4t._4bl9').text
+
+    parsed_first_date, empty_first = extract_date(month_first, day_first, raw_time_str_first)
+
+    if not parsed_first_date:
+        print("Failed to match time from '{}'".format(raw_time_str_first))
+        return
+
+#extract Second Date from recurring list
+    month_second = next_dates[1].find_element_by_class_name('_5a4-').text
+    day_second = next_dates[1].find_element_by_class_name('_5a4z').text
+    raw_time_str_second = next_dates[1].find_element_by_css_selector('._2l4t._4bl9').text
+
+    parsed_second_date, empty_second = extract_date(month_second, day_second, raw_time_str_second)
+
+    if not parsed_second_date:
+        print("Failed to match time from '{}'".format(raw_time_str_second))
+        return
 
     new_recurring_event = Event(
         name=recurring_element_container.find_element_by_css_selector('._2l3f._2pic').text,
         venue=recurring_element_container.find_element_by_css_selector('._2l3g._2pic').text,
-        first_date='{} {} {}'.format(next_dates[0].find_element_by_class_name('_5a4-').text,
-                                     next_dates[0].find_element_by_class_name('_5a4z').text,
-                                     next_dates[0].find_element_by_css_selector('._2l4t._4bl9').text),
-        second_date='{} {} {}'.format(next_dates[1].find_element_by_class_name('_5a4-').text,
-                                      next_dates[1].find_element_by_class_name('_5a4z').text,
-                                      next_dates[1].find_element_by_css_selector('._2l4t._4bl9').text)
+        first_date=parsed_first_date,
+        second_date=parsed_second_date
     )
 
     session.add(new_recurring_event)
@@ -157,6 +176,7 @@ for fb_page in config.fb_pages:
     for element_container in elements_containers:
         process_event(element_container)
 
+    #since not all pages have recurring events we will try to retrieve recurring events and if not, pass
     try:
         recurring_elements_containers = driver.find_elements_by_css_selector('._j6k.clearfix._ikh')
         for recurring_element_container in recurring_elements_containers:

--- a/scrape_events.py
+++ b/scrape_events.py
@@ -32,7 +32,7 @@ class Event(Base):
     second_date = Column(DateTime)
 
     def __repr__(self):
-        return "<Event(name='%s', venue='%s', start_date='%s', end_date='%s', first_date='%s'), second_date='%s'>" % (
+        return "<Event(name='%s', venue='%s', start_date='%s', end_date='%s', first_date='%s', second_date='%s')>" % (
             self.name, self.venue, self.start_date, self.end_date, self.first_date, self.second_date
         )
 

--- a/scrape_events.py
+++ b/scrape_events.py
@@ -176,14 +176,9 @@ for fb_page in config.fb_pages:
     for element_container in elements_containers:
         process_event(element_container)
 
-    #since not all pages have recurring events we will try to retrieve recurring events and if not, pass
-    try:
-        recurring_elements_containers = driver.find_elements_by_css_selector('._j6k.clearfix._ikh')
-        for recurring_element_container in recurring_elements_containers:
-            process_recurring_event(recurring_element_container)
-    except Exception as e:
-        pass
-
+    recurring_elements_containers = driver.find_elements_by_css_selector('._j6k.clearfix._ikh')
+    for recurring_element_container in recurring_elements_containers:
+        process_recurring_event(recurring_element_container)
 
 # TODO quit even if there is an exception
 driver.quit()

--- a/scrape_events.py
+++ b/scrape_events.py
@@ -126,36 +126,26 @@ def process_event(element_container):
 
 def process_recurring_event(recurring_element_container):
 
-#list with the next 2 dates for recurring events
+    # list with the next 2 dates for recurring events
     next_dates = recurring_element_container.find_elements_by_css_selector('._2l43.clearfix._ikh')
+    next_dates_parsed = []
 
-#extract First Date from recurring list
-    month_first = next_dates[0].find_element_by_class_name('_5a4-').text
-    day_first = next_dates[0].find_element_by_class_name('_5a4z').text
-    raw_time_str_first = next_dates[0].find_element_by_css_selector('._2l4t._4bl9').text
+    for next_date in next_dates:
+        month_first = next_date.find_element_by_class_name('_5a4-').text
+        day_first = next_date.find_element_by_class_name('_5a4z').text
+        raw_time_str_first = next_date.find_element_by_css_selector('._2l4t._4bl9').text
 
-    parsed_first_date, empty_first = extract_date(month_first, day_first, raw_time_str_first)
-
-    if not parsed_first_date:
-        print("Failed to match time from '{}'".format(raw_time_str_first))
-        return
-
-#extract Second Date from recurring list
-    month_second = next_dates[1].find_element_by_class_name('_5a4-').text
-    day_second = next_dates[1].find_element_by_class_name('_5a4z').text
-    raw_time_str_second = next_dates[1].find_element_by_css_selector('._2l4t._4bl9').text
-
-    parsed_second_date, empty_second = extract_date(month_second, day_second, raw_time_str_second)
-
-    if not parsed_second_date:
-        print("Failed to match time from '{}'".format(raw_time_str_second))
-        return
+        parsed_date, _ = extract_date(month_first, day_first, raw_time_str_first)
+        if not parsed_date:
+            print("Failed to match time from '{}'".format(raw_time_str_first))
+            return
+        next_dates_parsed.append(parsed_date)
 
     new_recurring_event = Event(
         name=recurring_element_container.find_element_by_css_selector('._2l3f._2pic').text,
         venue=recurring_element_container.find_element_by_css_selector('._2l3g._2pic').text,
-        first_date=parsed_first_date,
-        second_date=parsed_second_date
+        first_date=next_dates_parsed[0],
+        second_date=next_dates_parsed[1],
     )
 
     session.add(new_recurring_event)


### PR DESCRIPTION
Added the capability to scrape recurring events with the next 2 dates on which the event takes place. The 2 dates are displayed in the index page as: "Events @ Venue at First_date and Second_date" versus a regular one time event displayed as: "Events @ Venue at Start_date"

**Errors to fix: Past events which occurred last year(it does not show the year) are parsed as belonging to this year. The only viable solution is to read Upcoming Events from the "Upcoming Events" container only.**