### PR TITLE
Quick fix to search only in the upcoming events container for events.…

### DIFF
--- a/scrape_events.py
+++ b/scrape_events.py
@@ -162,7 +162,8 @@ for fb_page in config.fb_pages:
     driver.execute_script("return arguments[0].scrollIntoView();", past_events)
     time.sleep(5)
 
-    elements_containers = driver.find_elements_by_class_name('_24er') #identifies the paragraph containing the each event
+    upcoming_elements_container = driver.find_element_by_id("upcoming_events_card") #identifies the upcoming events container
+    elements_containers = upcoming_elements_container.find_elements_by_class_name('_24er') #identifies event paragraph(event) in upcoming events container
     for element_container in elements_containers:
         process_event(element_container)
 


### PR DESCRIPTION
… The scraper will no longer look into past events container. Pending: 1. To remove the date verification in process event function(if parsed_start_date < current_day_start: return); 2. To test if we can remove the scrolling down to past_events card